### PR TITLE
fix(pkg): upgrade xml-crypto to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "passport-strategy": "^1.0.0",
     "uid2": "0.0.x",
     "valid-url": "^1.0.9",
-    "xml-crypto": "auth0/xml-crypto#v1.4.1-auth0.2",
+    "xml-crypto": "^2.1.2",
     "xml-encryption": "^1.2.1",
     "xpath": "0.0.5",
     "xtend": "~2.0.3"


### PR DESCRIPTION
Addresses:
```
npm WARN deprecated xmldom@0.1.27: Deprecated due to CVE-2021-21366 resolved in 0.5.0
```